### PR TITLE
fix(server-renderer): refactor renderComponentVNode to be async

### DIFF
--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -86,37 +86,25 @@ export function createBuffer() {
   }
 }
 
-export function renderComponentVNode(
+export async function renderComponentVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string,
-): SSRBuffer | Promise<SSRBuffer> {
+): Promise<SSRBuffer> {
   const instance = createComponentInstance(vnode, parentComponent, null)
-  const res = setupComponent(instance, true /* isSSR */)
-  const hasAsyncSetup = isPromise(res)
-  const getPrefetches = () => instance.sp /* LifecycleHooks.SERVER_PREFETCH */
-  if (hasAsyncSetup || getPrefetches()) {
-    const setupResolved: Promise<unknown> = hasAsyncSetup
-      ? (res as Promise<void>)
-      : Promise.resolve()
-    const setupAndPrefetched = setupResolved
-      .then(() => {
-        // instance.sp may be null until an async setup resolves, so evaluate it here
-        const prefetches = getPrefetches()
-        if (prefetches) {
-          return Promise.all(
-            prefetches.map(prefetch => prefetch.call(instance.proxy)),
-          )
-        }
-      })
+  await setupComponent(instance, true /* isSSR */)
+  if (instance.sp) {
+    /* LifecycleHooks.SERVER_PREFETCH */
+    try {
+      await Promise.all(
+        instance.sp.map(prefetch => prefetch.call(instance.proxy)),
+      )
+    } catch (error) {
+      // NOOP
       // Note: error display is already done by the wrapped lifecycle hook function.
-      .catch(NOOP)
-    return setupAndPrefetched.then(() =>
-      renderComponentSubTree(instance, slotScopeId),
-    )
-  } else {
-    return renderComponentSubTree(instance, slotScopeId)
+    }
   }
+  return renderComponentSubTree(instance, slotScopeId)
 }
 
 function renderComponentSubTree(


### PR DESCRIPTION
Refactors `renderComponentVNode` to be async, which allows the implementation to be a little more simple and less repetitive. This removes some internal logic, and it now always returns a promise.